### PR TITLE
Refactor DesignSpecFrameLayout to draw on top of content.

### DIFF
--- a/library/src/main/java/org/lucasr/dspec/DesignSpecFrameLayout.java
+++ b/library/src/main/java/org/lucasr/dspec/DesignSpecFrameLayout.java
@@ -45,7 +45,6 @@ public class DesignSpecFrameLayout extends FrameLayout {
 
     public DesignSpecFrameLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        setWillNotDraw(false);
 
         final TypedArray a =
                 context.obtainStyledAttributes(attrs, R.styleable.DesignSpecFrameLayout, defStyle, 0);
@@ -57,8 +56,8 @@ public class DesignSpecFrameLayout extends FrameLayout {
     }
 
     @Override
-    protected void onDraw(Canvas canvas) {
-        super.onDraw(canvas);
+    protected void dispatchDraw(Canvas canvas) {
+        super.dispatchDraw(canvas);
 
         if (mDesignSpec != null) {
             mDesignSpec.draw(canvas);


### PR DESCRIPTION
The problem with using onDraw() in a ViewGroup is that this method actually draws **_underneath**_ the child view contents. This is an acceptable scenario for a basic layout with lots of transparency, but as soon as your view hierarchy starts including any significant amount of background images or colors, the grid becomes completely invisible.

To properly draw **_over**_ the content in a ViewGroup, override dispatchDraw() and call your custom code after super. A nice side-effect of this is that you no longer has to disable the drawing optimization in ViewGroup either.
