### PR TITLE
[readme] Update maven instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ or Maven:
   <groupId>org.lucasr.dspec</groupId>
   <artifactId>dspec</artifactId>
   <version>0.1.1</version>
+  <type>aar</type>
 </dependency>
 ```
 


### PR DESCRIPTION
You have to specify the type for maven, if you don't, the aar file is not downloaded.
