### PR TITLE
Add option to split the baseline grid.

### DIFF
--- a/sample/src/main/java/org/lucasr/dspec/sample/MainActivity.java
+++ b/sample/src/main/java/org/lucasr/dspec/sample/MainActivity.java
@@ -20,12 +20,12 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.MenuItem.OnMenuItemClickListener;
 import android.widget.ListView;
-
-import org.lucasr.dspec.DesignSpecFrameLayout;
-
 import butterknife.ButterKnife;
 import butterknife.InjectView;
+import org.lucasr.dspec.DesignSpec.From;
+import org.lucasr.dspec.DesignSpecFrameLayout;
 
 public final class MainActivity extends Activity {
     @InjectView(R.id.list) ListView mList;
@@ -37,7 +37,6 @@ public final class MainActivity extends Activity {
 
         setContentView(R.layout.main_activity);
         ButterKnife.inject(this);
-
         mList.setAdapter(new SimpleAdapter(this));
     }
 
@@ -55,6 +54,22 @@ public final class MainActivity extends Activity {
                         return true;
                     }
                 });
+
+        menu.add("Split baseline grid")
+               .setCheckable(true)
+               .setChecked(mDesignSpecLayout.getDesignSpec().isBaselineGridSplit())
+               .setOnMenuItemClickListener(new OnMenuItemClickListener() {
+                 @Override public boolean onMenuItemClick(MenuItem item) {
+                       boolean checked = !item.isChecked();
+                       item.setChecked(checked);
+                       if (checked) {
+                           mDesignSpecLayout.getDesignSpec().setBaselineGridSplit(48, From.BOTTOM);
+                       } else {
+                           mDesignSpecLayout.getDesignSpec().clearBaselineGridSplit();
+                       }
+                       return true;
+                 }
+               });
 
         menu.add(getString(R.string.show_keylines))
                 .setCheckable(true)

--- a/sample/src/main/res/layout/main_activity.xml
+++ b/sample/src/main/res/layout/main_activity.xml
@@ -31,4 +31,16 @@
         android:divider="@null"
         android:dividerHeight="0px"/>
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:paddingLeft="24dp"
+        android:paddingBottom="12dp"
+        android:textSize="14sp"
+        android:text="Snack attack!"
+        android:background="#323232"
+        android:textColor="@android:color/white"
+        android:gravity="bottom"
+        android:layout_gravity="bottom"
+        />
 </org.lucasr.dspec.DesignSpecFrameLayout>

--- a/sample/src/main/res/raw/main_activity_spec.json
+++ b/sample/src/main/res/raw/main_activity_spec.json
@@ -1,6 +1,10 @@
 {
     "baselineGridVisible": true,
     "baselineGridCellSize": 8,
+    "baselineGridSplit": {
+        "offset": 48,
+        "from": "BOTTOM"
+    },
     "keylines": [
         { "offset": 16,
           "from": "LEFT" },


### PR DESCRIPTION
It's not uncommon for a design to call for bottom-anchored content, such
as buttons, snackbars, drawers, etc.  Such content should be
grid-aligned internally, but its grid should originate at the bottom of
the screen and may not align with the top-anchored grid.

This change adds an option to split the grid at a given point on the
screen. There will then be two grids, one originating at TOP and one at
BOTTOM. If the grids do not align, a "gutter" will be left between them
to indicate the odd space. The gutter will always be narrower than the
baseline grid size.

![dspec_split_grid-2](https://cloud.githubusercontent.com/assets/18877/5668621/f5d21e94-973e-11e4-872e-04f434ad2865.png)
